### PR TITLE
feat: automatic configType detection based on ESLint version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,20 +64,6 @@ export default {
 };
 ```
 
-When using ESLint flat config, set the `configType` option to `flat`:
-
-```js
-import ESLintPlugin from 'eslint-rspack-plugin';
-
-export default {
-  plugins: [
-    new ESLintPlugin({
-      configType: 'flat',
-    }),
-  ],
-};
-```
-
 ## Options
 
 You can pass [ESLint options](https://eslint.org/docs/developer-guide/nodejs-api#-new-eslintoptions).
@@ -120,7 +106,9 @@ Specify the path to the cache location. Can be a file or a directory.
 type configType = 'flat' | 'eslintrc';
 ```
 
-- Default: `eslintrc`
+- Default:
+  - For ESLint < 10.0.0: `eslintrc`
+  - For ESLint >= 10.0.0: `flat`
 
 Specify the type of configuration to use with ESLint.
 

--- a/src/getESLint.js
+++ b/src/getESLint.js
@@ -61,10 +61,10 @@ async function loadESLint(options) {
  * @returns {Promise<Linter>}
  */
 async function loadESLintThreaded(key, poolSize, options) {
-  const cacheKey = getCacheKey(key, options);
   const configType = getConfigType(options);
   const optionsWithConfigType = { ...options, configType };
-  const { eslintPath = 'eslint' } = options;
+  const cacheKey = getCacheKey(key, optionsWithConfigType);
+  const { eslintPath = 'eslint' } = optionsWithConfigType;
   const source = require.resolve('./worker');
   const workerOptions = {
     enableWorkerThreads: true,

--- a/src/getESLint.js
+++ b/src/getESLint.js
@@ -62,9 +62,9 @@ async function loadESLint(options) {
  */
 async function loadESLintThreaded(key, poolSize, options) {
   const configType = getConfigType(options);
-  const optionsWithConfigType = { ...options, configType };
-  const cacheKey = getCacheKey(key, optionsWithConfigType);
-  const { eslintPath = 'eslint' } = optionsWithConfigType;
+  const resolvedOptions = { ...options, configType };
+  const cacheKey = getCacheKey(key, resolvedOptions);
+  const { eslintPath = 'eslint' } = resolvedOptions;
   const source = require.resolve('./worker');
   const workerOptions = {
     enableWorkerThreads: true,
@@ -73,12 +73,12 @@ async function loadESLintThreaded(key, poolSize, options) {
       {
         eslintPath,
         configType,
-        eslintOptions: getESLintOptions(optionsWithConfigType),
+        eslintOptions: getESLintOptions(resolvedOptions),
       },
     ],
   };
 
-  const local = await loadESLint(optionsWithConfigType);
+  const local = await loadESLint(resolvedOptions);
 
   let worker = /** @type {Worker?} */ (new JestWorker(source, workerOptions));
 


### PR DESCRIPTION
## Summary

When configType is not specified, default to 'flat' for ESLint >= 10.0.0 and 'eslintrc' for older versions. Update related documentation to reflect this change.