### PR TITLE
fix: fail build on eslint errors and warnings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,9 @@ class ESLintRspackPlugin {
       /** @type {string[]} */
       const files = [];
 
+      /** @type {Error | null} */
+      let linterError = null;
+
       const shouldLintAllFiles = this.options.lintAllFiles;
       const allMatchingFiles = shouldLintAllFiles
         ? globSync(wanted, { dot: true, ignore: exclude })
@@ -120,6 +123,20 @@ class ESLintRspackPlugin {
         }
       });
 
+      // await and interpret results
+      compilation.hooks.additionalAssets.tapAsync(
+        this.key,
+        /**
+         * @param {(error?: Error | null) => void} callback
+         */
+        (callback) => {
+          processResults().then(
+            (error) => callback(error),
+            (error) => callback(error),
+          );
+        },
+      );
+
       try {
         ({ lint, report, threads } = await linter(
           this.key,
@@ -127,6 +144,7 @@ class ESLintRspackPlugin {
           compilation,
         ));
       } catch (e) {
+        linterError = e;
         compilation.errors.push(e);
         return;
       }
@@ -187,22 +205,11 @@ class ESLintRspackPlugin {
         }
         if (files.length > 0 && threads <= 1) lint(files);
       });
-
-      // await and interpret results
-      compilation.hooks.additionalAssets.tapAsync(
-        this.key,
-        /**
-         * @param {(error?: Error | null) => void} callback
-         */
-        (callback) => {
-          processResults().then(
-            (error) => callback(error),
-            (error) => callback(error),
-          );
-        },
-      );
-
       async function processResults() {
+        if (linterError) {
+          return linterError;
+        }
+
         const { errors, warnings, generateReportAsset } = await report();
 
         if (warnings) {

--- a/src/index.js
+++ b/src/index.js
@@ -189,28 +189,43 @@ class ESLintRspackPlugin {
       });
 
       // await and interpret results
-      compilation.hooks.additionalAssets.tapPromise(this.key, processResults);
+      compilation.hooks.additionalAssets.tapAsync(
+        this.key,
+        /**
+         * @param {(error?: Error | null) => void} callback
+         */
+        (callback) => {
+          processResults().then(
+            (error) => callback(error),
+            (error) => callback(error),
+          );
+        },
+      );
 
       async function processResults() {
         const { errors, warnings, generateReportAsset } = await report();
 
-        if (warnings && !options.failOnWarning) {
+        if (warnings) {
           // @ts-ignore
           compilation.warnings.push(warnings);
-        } else if (warnings) {
-          // @ts-ignore
-          compilation.errors.push(warnings);
         }
 
-        if (errors && !options.failOnError) {
-          // @ts-ignore
-          compilation.warnings.push(errors);
-        } else if (errors) {
+        if (errors) {
           // @ts-ignore
           compilation.errors.push(errors);
         }
 
         if (generateReportAsset) await generateReportAsset(compilation);
+
+        if (errors && options.failOnError) {
+          return errors;
+        }
+
+        if (warnings && options.failOnWarning) {
+          return warnings;
+        }
+
+        return null;
       }
     });
   }

--- a/test/fail-on-config.test.js
+++ b/test/fail-on-config.test.js
@@ -3,17 +3,10 @@ import { join } from 'path';
 import pack from './utils/pack';
 
 describe('fail on config', () => {
-  it('fails when .eslintrc is not a proper format', async () => {
+  it('fails the build when .eslintrc is not a proper format', async () => {
     const overrideConfigFile = join(__dirname, '.badeslintrc');
     const compiler = pack('error', { overrideConfigFile });
 
-    const stats = await compiler.runAsync();
-    const { errors } = stats.compilation;
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toMatch(
-      /ESLint configuration in --config is invalid/i,
-    );
+    await expect(compiler.runAsync()).rejects.toThrow();
   });
 });

--- a/test/fail-on-error.test.js
+++ b/test/fail-on-error.test.js
@@ -4,21 +4,20 @@ describe('fail on error', () => {
   it('should emits errors', async () => {
     const compiler = pack('error', { failOnError: true });
 
-    const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    await expect(compiler.runAsync()).rejects.toThrow();
   });
 
   it('should emit warnings when disabled', async () => {
     const compiler = pack('error', { failOnError: false });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
-    expect(stats.hasWarnings()).toBe(true);
+    expect(stats.hasErrors()).toBe(true);
   });
 
   it('should correctly identifies a success', async () => {
     const compiler = pack('good', { failOnError: true });
 
-    await compiler.runAsync();
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(false);
   });
 });

--- a/test/fail-on-error.test.js
+++ b/test/fail-on-error.test.js
@@ -1,13 +1,13 @@
 import pack from './utils/pack';
 
 describe('fail on error', () => {
-  it('should emits errors', async () => {
+  it('should fail the build when failOnError is enabled', async () => {
     const compiler = pack('error', { failOnError: true });
 
     await expect(compiler.runAsync()).rejects.toThrow();
   });
 
-  it('should emit warnings when disabled', async () => {
+  it('should not fail the build when failOnError is disabled', async () => {
     const compiler = pack('error', { failOnError: false });
 
     const stats = await compiler.runAsync();

--- a/test/fail-on-warning.test.js
+++ b/test/fail-on-warning.test.js
@@ -4,8 +4,7 @@ describe('fail on warning', () => {
   it('should emits errors', async () => {
     const compiler = pack('warn', { failOnWarning: true });
 
-    const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    await expect(compiler.runAsync()).rejects.toThrow();
   });
 
   it('should correctly identifies a success', async () => {

--- a/test/fail-on-warning.test.js
+++ b/test/fail-on-warning.test.js
@@ -1,7 +1,7 @@
 import pack from './utils/pack';
 
 describe('fail on warning', () => {
-  it('should emits errors', async () => {
+  it('should fail the build when failOnWarning is enabled', async () => {
     const compiler = pack('warn', { failOnWarning: true });
 
     await expect(compiler.runAsync()).rejects.toThrow();

--- a/test/flat-config.test.js
+++ b/test/flat-config.test.js
@@ -6,7 +6,7 @@ import { ESLint } from 'eslint';
 (ESLint && parseFloat(ESLint.version) >= 9 ? describe.skip : describe)(
   'succeed on flat-configuration',
   () => {
-    it('cannot load FlatESLint class on default ESLint module', async () => {
+    it('fails the build when FlatESLint cannot be loaded from the default ESLint module', async () => {
       const overrideConfigFile = join(__dirname, 'fixtures', 'flat-config.js');
       const compiler = pack('full-of-problems', {
         configType: 'flat',
@@ -14,14 +14,7 @@ import { ESLint } from 'eslint';
         threads: 1,
       });
 
-      const stats = await compiler.runAsync();
-      const { errors } = stats.compilation;
-
-      expect(stats.hasErrors()).toBe(true);
-      expect(errors).toHaveLength(1);
-      expect(errors[0].message).toMatch(
-        /Couldn't find FlatESLint, you might need to set eslintPath to 'eslint\/use-at-your-own-risk'/i,
-      );
+      await expect(compiler.runAsync()).rejects.toThrow();
     });
 
     (process.version.match(/^v(\d+\.\d+)/)[1] >= 20 ? it : it.skip)(

--- a/test/multiple-instances.test.js
+++ b/test/multiple-instances.test.js
@@ -32,9 +32,7 @@ describe('multiple instances', () => {
       },
     );
 
-    const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    await expect(compiler.runAsync()).rejects.toThrow();
   });
 
   it('should fail on second instance', async () => {
@@ -49,8 +47,6 @@ describe('multiple instances', () => {
       },
     );
 
-    const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    await expect(compiler.runAsync()).rejects.toThrow();
   });
 });

--- a/test/utils/conf.js
+++ b/test/utils/conf.js
@@ -29,6 +29,7 @@ export default (entry, pluginConf = {}, webpackConf = {}) => {
         ignore: false,
         // TODO: update tests to run both states: test.each([[{threads: false}], [{threads: true}]])('it should...', async ({threads}) => {...})
         threads: true,
+        failOnError: false,
         ...pluginConf,
       }),
     ],


### PR DESCRIPTION
## Summary

This PR fixes `failOnError` and `failOnWarning` so lint failures can fail the Rspack compilation instead of only being recorded in stats, keeping CLI and CI exit status aligned with the documented options. ESLint errors and warnings are still emitted to compilation diagnostics, while enabled fail options now pass the formatted lint error through the async hook callback. Because `failOnError` defaults to `true`, projects with existing ESLint errors will now fail the build as documented.

## Related Links

Fixes https://github.com/rstackjs/eslint-rspack-plugin/issues/14
References https://github.com/webpack/eslint-webpack-plugin/pull/275
