### PR TITLE
fix!: derive failOnError default from mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,9 @@ The warnings found will always be emitted, to disable set to `false`.
 type failOnError = boolean;
 ```
 
-- Default: `true`
+- Default:
+  - `false` when [mode](https://rspack.rs/config/mode) is `development`
+  - `true` otherwise
 
 Will cause the module build to fail if there are any errors, to disable set to `false`.
 

--- a/docs/migrate-v4-to-v5.md
+++ b/docs/migrate-v4-to-v5.md
@@ -49,3 +49,9 @@ export default {
 ```
 
 `eslintrc` is deprecated by ESLint, so flat config is the recommended migration target.
+
+### `failOnError` Follows Compiler Mode
+
+In v4, `failOnError` defaulted to `true`. In v5, it defaults to `false` when [mode](https://rspack.rs/config/mode) is `development`, and `true` otherwise.
+
+Set `failOnError: true` explicitly if development builds should still fail on ESLint errors.

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,12 @@ class ESLintRspackPlugin {
     // Generate key for each compilation,
     // this differentiates one from the other when being cached.
     this.key = compiler.name || `${this.key}_${(compilerId += 1)}`;
+    if (
+      this.options.failOnError === null ||
+      typeof this.options.failOnError === 'undefined'
+    ) {
+      this.options.failOnError = compiler.options.mode !== 'development';
+    }
 
     const excludedFiles = parseFiles(
       this.options.exclude || [],

--- a/src/index.js
+++ b/src/index.js
@@ -35,10 +35,7 @@ class ESLintRspackPlugin {
     // Generate key for each compilation,
     // this differentiates one from the other when being cached.
     this.key = compiler.name || `${this.key}_${(compilerId += 1)}`;
-    if (
-      this.options.failOnError === null ||
-      this.options.failOnError === undefined
-    ) {
+    if (this.options.failOnError === undefined) {
       this.options.failOnError = compiler.options.mode !== 'development';
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ class ESLintRspackPlugin {
     this.key = compiler.name || `${this.key}_${(compilerId += 1)}`;
     if (
       this.options.failOnError === null ||
-      typeof this.options.failOnError === 'undefined'
+      this.options.failOnError === undefined
     ) {
       this.options.failOnError = compiler.options.mode !== 'development';
     }

--- a/src/options.js
+++ b/src/options.js
@@ -53,7 +53,6 @@ function getOptions(pluginOptions) {
     extensions: 'js',
     emitError: true,
     emitWarning: true,
-    failOnError: true,
     resourceQueryExclude: [],
     ...pluginOptions,
     ...(pluginOptions.quiet ? { emitError: true, emitWarning: false } : {}),

--- a/test/fail-on-error.test.js
+++ b/test/fail-on-error.test.js
@@ -1,6 +1,19 @@
 import pack from './utils/pack';
 
 describe('fail on error', () => {
+  it('should fail the build by default outside development mode', async () => {
+    const compiler = pack('error', {}, { mode: 'production' });
+
+    await expect(compiler.runAsync()).rejects.toThrow();
+  });
+
+  it('should not fail the build by default in development mode', async () => {
+    const compiler = pack('error');
+
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(true);
+  });
+
   it('should fail the build when failOnError is enabled', async () => {
     const compiler = pack('error', { failOnError: true });
 

--- a/test/multiple-instances.test.js
+++ b/test/multiple-instances.test.js
@@ -26,8 +26,16 @@ describe('multiple instances', () => {
       {},
       {
         plugins: [
-          new ESLintPlugin({ ignore: false, exclude: 'good.js' }),
-          new ESLintPlugin({ ignore: false, exclude: 'error.js' }),
+          new ESLintPlugin({
+            ignore: false,
+            exclude: 'good.js',
+            failOnError: true,
+          }),
+          new ESLintPlugin({
+            ignore: false,
+            exclude: 'error.js',
+            failOnError: true,
+          }),
         ],
       },
     );
@@ -41,8 +49,16 @@ describe('multiple instances', () => {
       {},
       {
         plugins: [
-          new ESLintPlugin({ ignore: false, exclude: 'error.js' }),
-          new ESLintPlugin({ ignore: false, exclude: 'good.js' }),
+          new ESLintPlugin({
+            ignore: false,
+            exclude: 'error.js',
+            failOnError: true,
+          }),
+          new ESLintPlugin({
+            ignore: false,
+            exclude: 'good.js',
+            failOnError: true,
+          }),
         ],
       },
     );

--- a/test/utils/conf.js
+++ b/test/utils/conf.js
@@ -32,7 +32,6 @@ export default (entry, pluginConf = {}, webpackConf = {}) => {
         ignore: false,
         // TODO: update tests to run both states: test.each([[{threads: false}], [{threads: true}]])('it should...', async ({threads}) => {...})
         threads: true,
-        failOnError: false,
         ...pluginConf,
       }),
     ],


### PR DESCRIPTION
## Summary

This PR ports the upstream `eslint-webpack-plugin` behavior that derives the default `failOnError` value from the Rspack `mode` option. Development builds now keep reporting ESLint errors without failing by default, while production and non-development builds still fail unless users explicitly set `failOnError: false`.

The README and v4-to-v5 migration guide document the new breaking default, and tests cover both development and production defaults.