### PR TITLE
chore!: drop Node 18 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20.x]
+        node-version: [20.19.0]
 
     runs-on: ${{ matrix.os }}
 
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [20.x]
+        node-version: [20.19.0]
 
     runs-on: ${{ matrix.os }}
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = (api) => {
         '@babel/preset-env',
         {
           targets: {
-            node: '18.18.0',
+            node: '20.19.0',
           },
         },
       ],

--- a/docs/migrate-v4-to-v5.md
+++ b/docs/migrate-v4-to-v5.md
@@ -10,11 +10,11 @@ ESLint 8 is no longer supported in v5.
 
 The supported ESLint peer dependency range is now `^9.0.0 || ^10.0.0`.
 
-### Drop Node 16 Support
+### Drop Node 18 Support
 
-Node.js 16 is no longer supported in v5.
+Node.js 18 is no longer supported in v5.
 
-The minimum supported Node.js version is now `>=18.18.0`.
+The minimum supported Node.js version is now `>=20.19.0`.
 
 ### Flat Config is the Default
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "engines": {
-    "node": ">= 18.18.0"
+    "node": ">= 20.19.0"
   },
   "scripts": {
     "start": "pnpm run build -- -w",


### PR DESCRIPTION
## Summary

This PR drops Node.js 18 from the supported runtime baseline for v5. It raises `engines.node` and the Babel target to Node.js `>=20.19.0`, pins CI to run against that minimum Node 20 version, and updates the v4-to-v5 migration guide to call out the breaking compatibility change.

Validated with `pnpm test`.