### PR TITLE
fix: use processAssets for reporting hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,12 +127,13 @@ class ESLintRspackPlugin {
       });
 
       // await and interpret results
-      compilation.hooks.additionalAssets.tapAsync(
+      compilation.hooks.processAssets.tapAsync(
         this.key,
         /**
+         * @param {Record<string, unknown>} _assets
          * @param {(error?: Error | null) => void} callback
          */
-        (callback) => {
+        (_assets, callback) => {
           processResults().then(
             (error) => callback(error),
             (error) => callback(error),


### PR DESCRIPTION
## Summary

Switch the ESLint result reporting stage from the legacy `additionalAssets` compatibility hook to `processAssets`, matching Rspack's current asset processing lifecycle while preserving the existing warning, error, and output report behavior.