### PR TITLE
fix: require Rspack builtModules support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,13 @@
     "types"
   ],
   "peerDependencies": {
+    "@rspack/core": "^1.0.8 || ^2.0.0",
     "eslint": "^9.0.0 || ^10.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@types/eslint": "^9.6.1",

--- a/src/index.js
+++ b/src/index.js
@@ -194,17 +194,10 @@ class ESLintRspackPlugin {
             }
           }
         } else if (this.options.lintDirtyModulesOnly) {
-          // compatible with old rspack which not support built modules
-          if (compilation.builtModules) {
-            for (const m of /** @type {Set<Module>} */ (
-              compilation.builtModules
-            )) {
-              addFile(m);
-            }
-          } else {
-            for (const m of compilation.modules) {
-              addFile(m);
-            }
+          for (const m of /** @type {Set<Module>} */ (
+            compilation.builtModules
+          )) {
+            addFile(m);
           }
         }
         if (files.length > 0 && threads <= 1) lint(files);


### PR DESCRIPTION
## Summary

This PR makes the Rspack compatibility boundary explicit by declaring `@rspack/core` as an optional peer dependency for `^1.0.8 || ^2.0.0`, matching the versions that expose `compilation.builtModules`. It also removes the legacy `compilation.modules` fallback in `lintDirtyModulesOnly`, so dirty-module linting now relies directly on `compilation.builtModules`.

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v1.0.8