### PR TITLE
fix: preserve ESLint setup error handling

### DIFF
--- a/src/getESLint.js
+++ b/src/getESLint.js
@@ -63,11 +63,34 @@ async function getESLint(options) {
  */
 async function loadESLintModule(specifier) {
   try {
+    // Prefer native ESM resolution for package specifiers so conditional
+    // exports use the import-compatible entry.
     return normalizeModule(await import(specifier));
-  } catch (_) {
+  } catch (e) {
+    if (!isImportResolutionError(e)) {
+      throw e;
+    }
+
+    // Fall back to CommonJS resolution only for legacy path-style eslintPath
+    // values, such as directories that ESM import cannot resolve directly.
     const resolvedPath = moduleRequire.resolve(specifier);
     return normalizeModule(await import(pathToFileURL(resolvedPath).href));
   }
+}
+
+/**
+ * @param {unknown} error
+ * @returns {boolean}
+ */
+function isImportResolutionError(error) {
+  if (!error || typeof error !== 'object') return false;
+
+  const { code } = /** @type {{ code?: string }} */ (error);
+  return (
+    code === 'ERR_MODULE_NOT_FOUND' ||
+    code === 'ERR_UNSUPPORTED_DIR_IMPORT' ||
+    code === 'MODULE_NOT_FOUND'
+  );
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ class ESLintRspackPlugin {
         await setupLinter;
 
         if (linterError) {
-          return linterError;
+          return options.failOnError ? linterError : null;
         }
 
         scheduleLint();

--- a/test/eslint-path.test.js
+++ b/test/eslint-path.test.js
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 
 import { getESLint } from '../src/getESLint.js';
 import pack from './utils/pack.js';
@@ -24,6 +25,32 @@ describe('eslint path', () => {
       }),
     ).rejects.toThrow(
       'eslint-rspack-plugin requires ESLint 9 or later. Make sure eslintPath resolves to an ESLint 9+ module that exports loadESLint().',
+    );
+  });
+
+  it('should preserve eslintPath module evaluation errors', async () => {
+    const eslintPath = `${
+      pathToFileURL(
+        join(import.meta.dirname, 'mock/eslint-import-error/index.js'),
+      ).href
+    }?runtime-error`;
+
+    await expect(
+      getESLint({
+        eslintPath,
+        configType: 'flat',
+      }),
+    ).rejects.toThrow('ESLint import failed during evaluation.');
+  });
+
+  it('should report eslintPath setup failures as compilation errors', async () => {
+    const eslintPath = join(import.meta.dirname, 'mock/eslint-no-load');
+    const compiler = pack('good', { eslintPath });
+
+    const stats = await compiler.runAsync();
+    expect(stats.hasErrors()).toBe(true);
+    expect(stats.compilation.errors[0].message).toContain(
+      'eslint-rspack-plugin requires ESLint 9 or later.',
     );
   });
 });

--- a/test/mock/eslint-import-error/index.js
+++ b/test/mock/eslint-import-error/index.js
@@ -1,0 +1,1 @@
+throw new Error('ESLint import failed during evaluation.');


### PR DESCRIPTION
## Summary

This PR follows up on the ESM migration by tightening `eslintPath` module loading so fallback resolution only handles import resolution failures while preserving real module evaluation errors. It also keeps linter setup failures as compilation errors when `failOnError` is disabled, while preserving fatal behavior when it is enabled.

## Related Links

https://github.com/rstackjs/eslint-rspack-plugin/pull/38