### PR TITLE
chore(deps): remove redundant eslint types

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "test:watch": "rstest --watch"
   },
   "dependencies": {
-    "@types/eslint": "^9.6.1",
     "micromatch": "^4.0.8",
     "normalize-path": "^3.0.0",
     "tinyglobby": "^0.2.15"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@types/eslint':
-        specifier: ^9.6.1
-        version: 9.6.1
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8
@@ -311,9 +308,6 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -968,11 +962,6 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/deep-eql@4.0.2': {}
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
 


### PR DESCRIPTION
## Summary

- Remove `@types/eslint` because ESLint 9 already ships the type declarations used by this package.
- Update the pnpm lockfile so the redundant production dependency is no longer installed.
- Validated with `pnpm run lint:types` and `pnpm run build`.