### PR TITLE
fix(types): allow string resourceQueryExclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,43 @@ Specify the files and/or directories to exclude. Must be relative to `options.co
 - Type:
 
 ```ts
-type resourceQueryExclude = RegExp | Array<RegExp>;
+type resourceQueryExclude = string | RegExp | Array<string | RegExp>;
 ```
 
 - Default: `[]`
 
-Specify the resource query to exclude.
+Exclude modules from linting when their resource query matches one of the
+provided patterns. The resource query is the part after `?` in an import, such
+as `raw` in `import './file.js?raw'`.
+
+String values are converted to `RegExp`. Use anchors when you need an exact
+match.
+
+```js
+import ESLintPlugin from 'eslint-rspack-plugin';
+
+export default {
+  plugins: [
+    new ESLintPlugin({
+      resourceQueryExclude: 'raw',
+    }),
+  ],
+};
+```
+
+You can also mix strings and `RegExp` values:
+
+```js
+import ESLintPlugin from 'eslint-rspack-plugin';
+
+export default {
+  plugins: [
+    new ESLintPlugin({
+      resourceQueryExclude: [/media/, '^raw$'],
+    }),
+  ],
+};
+```
 
 ### `files`
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -23,6 +23,8 @@ export type SeverityOptions = {
   warning?: Severity;
 };
 
+export type ResourceQueryExclude = string | RegExp | Array<string | RegExp>;
+
 export type PluginOptions = {
   context?: string;
   eslintPath?: string;
@@ -35,7 +37,7 @@ export type PluginOptions = {
   lintAllFiles?: boolean;
   severity?: SeverityOptions;
   outputReport?: OutputReport;
-  resourceQueryExclude?: RegExp | RegExp[];
+  resourceQueryExclude?: ResourceQueryExclude;
   configType?: string;
 };
 
@@ -46,7 +48,7 @@ export type ResolvedOptions = Options & {
   cacheLocation: string;
   configType: string;
   extensions: string | string[];
-  resourceQueryExclude: RegExp | RegExp[];
+  resourceQueryExclude: ResourceQueryExclude;
   severity: Required<SeverityOptions>;
 };
 

--- a/test/resource-query.test.js
+++ b/test/resource-query.test.js
@@ -17,4 +17,21 @@ describe('resource-query', () => {
     expect(stats.hasWarnings()).toBe(false);
     expect(stats.hasErrors()).toBe(false);
   });
+
+  it('should exclude the match resource query from string pattern', async () => {
+    const compiler = pack(
+      'resource-query',
+      {
+        resourceQueryExclude: 'media',
+        extensions: ['.js', '.ts'],
+      },
+      {
+        module: { rules: [{ resourceQuery: /media/, type: 'asset/source' }] },
+      },
+    );
+
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

This PR aligns the public `resourceQueryExclude` option type and docs with runtime behavior by allowing string patterns alongside `RegExp` values. It adds a shared option type, documents string conversion to `RegExp` with examples, and covers string patterns in the resource query test.