### PR TITLE
chore: build before stage publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Publish
         run: pnpm stage publish --no-git-checks

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "lint:js": "eslint --cache .",
     "lint:prettier": "prettier -w --list-different .",
     "lint:types": "tsc --pretty --noEmit",
-    "prepare": "pnpm run build",
     "security": "npm audit",
     "start": "rslib -w",
     "pretest": "pnpm run lint",


### PR DESCRIPTION
## Summary

- Build packages in the release workflow before `pnpm stage publish`.
- Remove the duplicate build command from `scripts.prepare`.
- Validation: checked staged publish workflow ordering and ran `git diff --check`.