### PR TITLE
chore: add bugs.url package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "rspack"
   ],
   "homepage": "https://github.com/rstackjs/eslint-rspack-plugin",
-  "bugs": "https://github.com/rstackjs/eslint-rspack-plugin/issues",
+  "bugs": {
+    "url": "https://github.com/rstackjs/eslint-rspack-plugin/issues"
+  },
   "repository": "https://github.com/rstackjs/eslint-rspack-plugin",
   "license": "MIT",
   "author": "Ricardo Gobbo de Souza <ricardogobbosouza@yahoo.com.br>",


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `eslint-rspack-plugin`
- updates only `package.json`

## Metadata added
- `bugs.url`: `https://github.com/rstackjs/eslint-rspack-plugin/issues`

## Validation
- parsed `package.json` as JSON after the change
- confirmed the changed manifest still has `name: eslint-rspack-plugin`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package point users to the project README and/or public issue tracker once the package is next released.