### PR TITLE
chore: reuse shared test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@eslint/js": "^9.39.4",
     "@rslib/core": "^0.23.2",
     "@rspack/core": "^2.0.2",
+    "@rstackjs/test-utils": "^0.2.0",
     "@rstest/core": "^0.9.10",
     "@types/fs-extra": "^11.0.4",
     "@types/micromatch": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@rspack/core':
         specifier: ^2.0.2
         version: 2.0.2(@swc/helpers@0.5.23)
+      '@rstackjs/test-utils':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@rstest/core':
         specifier: ^0.9.10
         version: 0.9.10
@@ -504,6 +507,9 @@ packages:
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
+
+  '@rstackjs/test-utils@0.2.0':
+    resolution: {integrity: sha512-P+LOo1WE3xYeGkHmEthyq2cIpN69k4LhiB/4UBSceD+nW9hDlhWv8MC0LTLWokZXccWl4ntcfOBjQFllkcBlPA==}
 
   '@rstest/core@0.9.10':
     resolution: {integrity: sha512-JUSUYYXWIHEBUn193u2RglZujvGPv46Blxpl17QFwc0y9vEXe2y/IfGwGrVsJfZz7PaWZ5NnbFf0J55YIIns+g==}
@@ -1437,6 +1443,8 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rspack/core': 2.1.3(@swc/helpers@0.5.21)
+
+  '@rstackjs/test-utils@0.2.0': {}
 
   '@rstest/core@0.9.10':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,4 @@ minimumReleaseAgeExclude:
   - '@rslint/*'
   - '@typescript/*'
   - typescript
+  - '@rstackjs/test-utils@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,4 +9,4 @@ minimumReleaseAgeExclude:
   - '@rslint/*'
   - '@typescript/*'
   - typescript
-  - '@rstackjs/test-utils@0.2.0'
+  - '@rstackjs/*'

--- a/test/formatter-write.test.js
+++ b/test/formatter-write.test.js
@@ -1,13 +1,15 @@
 import { join } from 'path';
 import { readFileSync, removeSync } from 'fs-extra';
 import { rspack } from '@rspack/core';
+import { normalizeEol } from '@rstackjs/test-utils';
 import conf from './utils/conf.js';
 import { stripVTControlCharacters } from 'node:util';
 
 const cleanContents = (contents) =>
-  stripVTControlCharacters(contents.split('error.js')[1])
-    .replace(/\r\n/g, '\n')
-    .replace(/\\r\\n/g, '\\n');
+  normalizeEol(stripVTControlCharacters(contents.split('error.js')[1])).replace(
+    /\\r\\n/g,
+    '\\n',
+  );
 
 describe('formatter write', () => {
   it('should write results to relative file with a custom formatter', () =>


### PR DESCRIPTION
## Summary

This PR replaces the test's local EOL normalization with `normalizeEol` from `@rstackjs/test-utils`, keeping common test behavior maintained in one package.